### PR TITLE
dal: support passing executor for parallel json parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ Homepage = "https://github.com/karlicoss/ghexport"
 
 
 [project.optional-dependencies]
-dal = []
+dal = ["more-itertools"]
 export = ["PyGithub"]
 optional = [
     "orjson",  # faster json processing

--- a/src/ghexport/dal.py
+++ b/src/ghexport/dal.py
@@ -1,12 +1,30 @@
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
+from concurrent.futures import Executor
 from pathlib import Path
+
+from more_itertools import chunked
 
 from .exporthelpers import dal_helper, logging_helper
 from .exporthelpers.dal_helper import Json, json_items, pathify
 
 logger = logging_helper.make_logger(__name__)
+
+
+def _process_path(path: Path) -> list[Json]:
+    """
+    Helper function to process one file -- needs to be on the top level in case ProcessPoolExecutor is used.
+    """
+    with path.open(mode='rb') as fo:
+        first = fo.read(1)
+    # in old format we just dumped the list of events directly
+    old_format = first == b'['
+    extractor = None if old_format else 'events'
+    items = json_items(path, extractor)
+
+    # by default they come in descending order
+    return sorted(items, key=lambda e: e['id'])
 
 
 # todo move DAL bits from hpi?
@@ -15,52 +33,67 @@ class DAL:
     Github only seems to give away last 300 events via the API, so we need to merge them
     """
 
-    def __init__(self, sources: Sequence[Path | str]) -> None:
+    def __init__(self, sources: Sequence[Path | str], *, executor: Executor | None = None) -> None:
+        """
+        executor: optional Executor (e.g. ThreadPoolExecutor) to use for CPU-bound tasks (e.g. parsing json).
+        """
         self.sources = list(map(pathify, sources))
+        self.executor = executor
+        self.enlighten = logging_helper.get_enlighten()
 
-    def _sources(self) -> Iterator[Path]:
-        pbar = logging_helper.get_enlighten().counter(total=len(self.sources), desc=f'{__name__}', unit='files')
+    # todo error handling?
+    def _raw(self) -> Iterator[tuple[Path, list[Json]]]:
+        progress_bar = self.enlighten.counter(total=len(self.sources), desc=f'{__name__}', unit='files')
+
+        executor = self.executor
+        _map = map if executor is None else executor.map
+        workers = 1 if executor is None else getattr(executor, '_max_workers')
+
+        total = len(self.sources)
+        width = len(str(total))
 
         # hmm. this is a bit meh, but will trial it for now and if it suits us, come up with some proper encapsulation
-        terminal = getattr(getattr(pbar, 'manager', object()), 'companion_term', object())
+        terminal = getattr(getattr(progress_bar, 'manager', object()), 'companion_term', object())
         # if we're using tty or a Mock (no enlighten, or it's turned off), this will be False
         use_enlighten = terminal.__class__.__name__ == 'Terminal'
         log_src = logger.debug if use_enlighten else logger.info
 
-        for src in self.sources:
-            log_src(f'{src} : processing...')
-            pbar.update()
-            yield src
+        def logged_sources() -> Iterable[Path]:
+            # helper iterator to log source paths before passing to the executor
+            # makes is a bit easier, e.g. don't have to pass log message to the function we run on executor
+            # TODO on the other hand if the executor is busy might be a little misleading (since we'll log way before processing)
+            # but on the other hand it also makes it a bit more obvious we're waiiting for it so idk
+            for idx, path in enumerate(self.sources):
+                log_src(f'processing [{idx:>{width}}/{total:>{width}}] {path}')
+                yield path
 
-    # todo error handling?
+        # Batch input data by the amount of available workers.
+        # This is to make sure that in case of slow consumer, results don't build up and we won't run out of memory.
+        for chunk in chunked(logged_sources(), n=workers):
+            results = _map(_process_path, chunk)
+            for path, group in zip(chunk, results, strict=True):
+                progress_bar.update()
+                yield path, group
+
     def events(self) -> Iterator[Json]:
         emitted: dict[str, Json] = {}
-        # todo maybe info level should be a bit smarter? e.g. log that we're processing every few seconds or something, at least in interactive mode?
-        for src in self._sources():
-            with src.open(mode='rb') as fo:
-                first = fo.read(1)
-            old_format = first == b'['
-            extractor = None if old_format else 'events'
-            jj = list(json_items(src, extractor))
-
-            # by default they come in descending order
-            jj = sorted(jj, key=lambda e: e['id'])
-
+        for path, group in self._raw():
+            # todo maybe info level should be a bit smarter? e.g. log that we're processing every few seconds or something, at least in interactive mode?
             before = len(emitted)
 
-            for e in jj:
+            for e in group:
                 eid = e['id']
                 prev = emitted.get(eid)
                 if prev is None:
                     emitted[eid] = e
                     yield e
                 elif prev != e:
-                    # never actually encountered the so just a warning..
-                    logger.warning('Mismatch: %s vs %s', prev, e)
+                    # never actually encountered this, so just a warning..
+                    logger.warning(f'{path}: mismatch {prev} vs {e}')
 
             after = len(emitted)
 
-            logger.debug('%s: added %d out of %d events', src, (after - before), len(jj))
+            logger.debug(f'{path}: added {after - before} out of {len(group)} events')
             # TODO how to configure logger via hpi?
             # TODO merging by id could be sort of generic
 


### PR DESCRIPTION
also generlaly more consistent logging/enlighten handling

```
$ hyperfine 'uu run --python=3.14t -m my.core query my.github.ghexport.events -s >/dev/null'
Benchmark 1: uu run --python=3.14t -m my.core query my.github.ghexport.events -s >/dev/null
  Time (mean ± σ):     14.634 s ±  0.153 s    [User: 12.254 s, System: 2.375 s]
  Range (min … max):   14.409 s … 14.853 s    10 runs

$ hyperfine 'HPI_THREAD_POOL=8 uu run --python=3.14t -m my.core query my.github.ghexport.events -s >/dev/null'
Benchmark 1: HPI_THREAD_POOL=8 uu run --python=3.14t -m my.core query my.github.ghexport.events -s >/dev/null
  Time (mean ± σ):      4.465 s ±  0.045 s    [User: 19.213 s, System: 3.913 s]
  Range (min … max):    4.405 s …  4.554 s    10 runs
```